### PR TITLE
Updated required Ruby version

### DIFF
--- a/ansible-vault.gemspec
+++ b/ansible-vault.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "listen", "< 3.1.0"
   spec.add_development_dependency "byebug", "~> 8.2"
   spec.add_development_dependency "yard", "~> 0.8.7"
+
+  spec.required_ruby_version = '>= 2.1.0'
 end


### PR DESCRIPTION
As you're using Ruby 2.1 keyword arguments syntax (https://robots.thoughtbot.com/ruby-2-keyword-arguments), I added a ruby version dependency. Otherwise you get confusing errors on older versions of Ruby. Alternatively, if you could revert to older syntax, this Gem would be available to older installations of Ruby, which as I know only too well are very common still :(
