### PR TITLE
Add support for password_file parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Yep, that's it! This call opens the vault file, verifies the included HMAC, and
 (assuming the HMAC checks out) decrypts the contents of the file and returns
 the String representation of the contents.
 
+Password can be substituted by password_file: "/path/to/password_file".
+
 ### Writing new contents to a vault 
 
 ```ruby

--- a/lib/ansible/vault.rb
+++ b/lib/ansible/vault.rb
@@ -27,12 +27,13 @@ module Ansible
     #
     # @param path [String, Pathname] The path to the file to read
     # @param password [String] The password for the file
+    # @param password_file [String, Pathname] A password file for the file
     # @param options [Hash] Additional options, see {#initialize} for details
     # @return [String] The plaintext contents of the vault, this is marked for
     #   zeroing before the GC reaps the object. Any data extracted/parsed from
     #   this string should be similarly wiped from memory when no longer used.
-    def self.read(path:, password:, **options)
-      new(path: path, password: password, **options).read
+    def self.read(path:, password: nil, password_file: nil, **options)
+      new(path: path, password: password, password_file: password_file, **options).read
     end
 
     # Encrypt plaintext using the supplied and write it to the specified location
@@ -40,26 +41,28 @@ module Ansible
     # @param path [String, Pathname] The path to the file to write, truncated
     #   before writing
     # @param password [String] The password for the file
+    # @param password_file [String, Pathname] A password file for the file
     # @param plaintext [String] The secrets to be protected
     # @param options [Hash] Additional options, see {#initialize} for details
     # @return [File] The closed file handle the vault was written to
-    def self.write(path:, password:, plaintext:, **options)
-      new(path: path, password: password, plaintext: plaintext, **options).write
+    def self.write(path:, password: nil, password_file: nil, plaintext:, **options)
+      new(path: path, password: password, password_file: password_file, plaintext: plaintext, **options).write
     end
 
     # Build a new Vault
     #
     # @param path [String, Pathname] The path to the file to read
     # @param password [String] The password for the file
+    # @param password_file [String, Pathname] A password file for the file    
     # @param options [Hash] Additional options
     # @param plaintext [String] The plaintext of the file to be written when
     #   encrypting
     # @option options [Boolean] :allow_blank_password Allow nil and empty string
     #   passwords, defaults to false.
-    def initialize(path:, password:, plaintext: :none, **options)
+    def initialize(path:, password: nil, password_file: nil, plaintext: :none, **options)
       @path = path.to_s
       @path = path
-      @password = validate_password(password, options).shred_later
+      @password = validate_password(password, password_file, options).shred_later
       @plaintext = plaintext
       @plaintext.shred_later if String === @plaintext
     end
@@ -101,7 +104,13 @@ module Ansible
 
     private
 
-    def validate_password(password, options)
+    def validate_password(password, password_file, options)
+      if !password.nil? && !password_file.nil?
+        raise Error, "Password and password_file cannot both be defined."
+      elsif !password_file.nil?
+        password = IO.binread(password_file).strip
+      end
+
       if !options[:allow_blank_password] && (password.nil? || password.strip.empty?)
         raise BlankPassword, 'A nil or empty string password was supplied!' \
           'If this is expected set the allow_blank_password option.'


### PR DESCRIPTION
Had to do a bit of detective work with another project on how Ansible reads password files with --vault-password-file.

Might be a nice convenience feature to include support for this directly.